### PR TITLE
take out full calender button

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,9 +262,9 @@
                                 <div class="d-flex align-items-center widget-post" id="calendarlist">
 
                                 </div>
-                                <div class="post-content">
+                                <!-- <div class="post-content">
                                     <p><a href="https://drive.google.com/open?id=1TrtNQK9uMG8HnrN99_gtBHcVLaACBOqN" class=" button_all" target="_blank"> Full calendar</a></p>
-                                </div>
+                                </div> -->
                             </div>
                         </div>
 


### PR DESCRIPTION
Since the content of the school calender is changing all the time. It doesn't make sense to hard code it in. We'll leave it to the News update and school calender to fullfil the function